### PR TITLE
Use internals instead of getAttribute and get_class

### DIFF
--- a/src/LogModelEvent.php
+++ b/src/LogModelEvent.php
@@ -31,13 +31,13 @@ class LogModelEvent extends Model
     // ----------------------------------------------
 
     public function scopeWhereUser(Builder $query, $user){
-        return $query->where('user_id',$user->id);
+        return $query->where('user_id', $user->getKey());
     }
 
     public function scopeWhereModel(Builder $query, $model){
         return $query->where([
-            'model_type' => get_class($model),
-            'model_id' => $model->id
+            'model_type' => $model->getMorphClass(),
+            'model_id' => $model->getKey(),
         ]);
     }
 

--- a/tests/abstractTest.php
+++ b/tests/abstractTest.php
@@ -61,8 +61,8 @@ abstract class abstractTest extends \Orchestra\Testbench\TestCase
 
     public function reloadModel(&$model)
     {
-        $className = get_class($model);
-        $model = $className::find($model->id);
+        $className = $model->getMorphClass();
+        $model = $className::find($model->getKey());
         return $model;
     }
 


### PR DESCRIPTION
To get the morph class you should use `$model->getMorphClass()` instead of `get_class($model)` as this makes it work with an users given morph map.

Also `->id` is not proper as some users may have anything else than `id` as a key, therefore we use `->getKey()`